### PR TITLE
Change the multiplication symbol

### DIFF
--- a/Errata/Chp_01.ipynb
+++ b/Errata/Chp_01.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "should be:\n",
     "\n",
-    "...the probability of the mass of the electron being $9.1 \times 10^{-31}$ kg..."
+    "...the probability of the mass of the electron being $9.1 \\times 10^{-31}$ kg..."
    ]
   },
   {

--- a/Errata/Chp_01.ipynb
+++ b/Errata/Chp_01.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "should be:\n",
     "\n",
-    "...the probability of the mass of the electron being $9.1 x 10^{-31}$ kg..."
+    "...the probability of the mass of the electron being $9.1 \times 10^{-31}$ kg..."
    ]
   },
   {


### PR DESCRIPTION
I think the `x` in $9.1 x 10^{-31}$ means multiply.
Using \times would avoid confusion.