### PR TITLE
fixing pip install error on conda env creation

### DIFF
--- a/bap.yml
+++ b/bap.yml
@@ -12,4 +12,4 @@ dependencies:
   - numpy=1.14.2
   - scipy=1.1
   - pip:
-    - pip install arviz=0.3.1
+    - arviz==0.3.1


### PR DESCRIPTION
Received the following error from the arviz pip installation
```
Invalid requirement: 'pip install arviz=0.3.1'
= is not a valid operator. Did you mean == ?
```
The reason we get this error is extra pip dependencies only need to state:

- the name of the library
- the version with `==`

I adjusted to the above formatting to remove the error

Reference:
https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually