### PR TITLE
Adding pip to YML and adding = sign for Pandas

### DIFF
--- a/bap.yml
+++ b/bap.yml
@@ -7,12 +7,13 @@ dependencies:
   - jupyter=1.0.0
   - matplotlib=3.0.2
   - pymc3=3.6
-  - pandas 0.23.4
+  - pandas=0.23.4
   - seaborn=0.9
   - numpy=1.14.2
   - scipy=1.1
   - graphviz=2.38.0
   - python-graphviz=0.8.4
+  - pip=20.2.4
   - pip:
     - arviz==0.3.1
     - watermark==2.0.1


### PR DESCRIPTION
Keeping conda from complaining that it's not been given a pip version.

Also the pandas requirement was somehow missing an `=` sign. I don't think this really affects anything, but just to be sure I added it.

Fixes #72 